### PR TITLE
Prevent crash if service responds with non-JSON content

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -11,7 +11,12 @@ const getRequest = async (url, isSecure = true) => {
         data += chunk;
       });
       resp.on('end', () => {
-        resolve(JSON.parse(data));
+        try {
+            let json = JSON.parse(data);
+            resolve(json);
+        } catch(e) {
+            reject(`Service ${url} did not respond with valid json`);
+        }
       });
     }).on('error', (err) => reject(err));
   });

--- a/lib/cron.js
+++ b/lib/cron.js
@@ -12,15 +12,27 @@ const checkAllServices = async () => {
     const actualServices = [];
     config['serviceList'].forEach(service => config[service].forEach(i => actualServices.push({...i, type: service })));
     return await Promise.map(actualServices, async (service) => {
-      switch (service.type) {
-        case 'insightInstances':
-          return {...await explorerCalls.getInsightStatus(service.url), ...service };
-        case 'DWSInstances':
-          return {...await dwsCalls.getDWSStatus(service.url), ...service };
-        case 'poolInstances':
-          return {...await poolCalls.getPoolStatus(service.url), ...service };
+      let status = {};
+
+      try {
+        switch (service.type) {
+          case 'insightInstances':
+            status = await explorerCalls.getInsightStatus(service.url);
+            break;
+          case 'DWSInstances':
+            status = await dwsCalls.getDWSStatus(service.url);
+            break;
+          case 'poolInstances':
+            status = await poolCalls.getPoolStatus(service.url);
+            break;
+        }
+      } catch(e) {
+        console.error(e);
       }
+
+      return {...status, ...service };
     });
+
   } catch (e) {
     throw e;
   }


### PR DESCRIPTION
Fixed a crash that happened if one of the pinged services responds with non-JSON content. 

The service `https://go.digibyte.io/dws/api/v2/feelevels` responds with a 502 status code, which caused the node process to exit.